### PR TITLE
Fixed false NPM script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Install
 
 ```sh
-yarn add / npm install @stereo/lavalink
+yarn add / npm install @stereo-bot/lavalink
 ```
 
 ## Usage


### PR DESCRIPTION
The install command had the package name `@stereo/lavalink` instead of `@stereo-bot/lavalink`.